### PR TITLE
ci: add e2e tests for CentOS/EPEL in packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -84,3 +84,13 @@ jobs:
       - fedora-stable
       - fedora-development
 
+  - job: tests
+    trigger: pull_request
+    identifier: e2e-centos
+    fmf_path: test/fmf
+    tmt_plan: plans/e2e
+    packages: [go-fdo-client-centos]
+    targets:
+      - epel-9
+      - epel-10
+


### PR DESCRIPTION
Add test job configuration to run end-to-end tests on EPEL 9 and 10 targets, matching the existing Fedora test structure.