### PR TITLE
chore(packit): allow automation for committers

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -105,6 +105,9 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    allowed_pr_authors:
+      - packit
+      - all_committers
     dist_git_branches: &fedora_dist_git_branches
       - "fedora-latest-stable"
       - "fedora-latest"
@@ -112,6 +115,9 @@ jobs:
 
   - job: bodhi_update
     trigger: commit
+    allowed_builders:
+      - packit
+      - all_committers
     dist_git_branches: *fedora_dist_git_branches
 
   # Fedora E2E Testing jobs


### PR DESCRIPTION
This way we can create MRs that once merged kick off the packit automation