### PR TITLE
Update to go1.25.5 for vulnerability fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fido-device-onboard/go-fdo-client
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/fido-device-onboard/go-fdo v0.0.0-20260116133239-94bd9c5d647c


### PR DESCRIPTION
fixes the vulnerabilities reported in:

```
λ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-4340
    Handshake messages may be processed at the incorrect encryption level in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4340
  Standard library
    Found in: crypto/tls@go1.25
    Fixed in: crypto/tls@go1.25.6
    Example traces found:
      #1: internal/tls/tls.go:60:25: tls.userAgentTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls tls.Conn.HandshakeContext
      #2: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls tls.Conn.Read
      #3: cmd/root.go:50:24: cmd.Execute calls cobra.Command.Execute, which eventually calls tls.Conn.Write
      #4: internal/tls/tls.go:60:25: tls.userAgentTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls tls.Dialer.DialContext

Vulnerability #2: GO-2025-4175
    Improper application of excluded DNS name constraints when verifying
    wildcard names in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4175
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.5
    Example traces found:
      #1: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls x509.Certificate.Verify

Vulnerability #3: GO-2025-4155
    Excessive resource consumption when printing error string for host
    certificate validation in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4155
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.5
    Example traces found:
      #1: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls x509.Certificate.Verify
      #2: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls x509.Certificate.VerifyHostname

Vulnerability #4: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.2
    Example traces found:
      #1: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls x509.Certificate.Verify

Vulnerability #5: GO-2025-4012
    Lack of limit when parsing cookies can cause memory exhaustion in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-4012
  Standard library
    Found in: net/http@go1.25
    Fixed in: net/http@go1.25.2
    Example traces found:
      #1: cmd/device_init.go:205:21: cmd.doDI calls fdo.DI, which eventually calls http.Client.Do

Vulnerability #6: GO-2025-4011
    Parsing DER payload can cause memory exhaustion in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2025-4011
  Standard library
    Found in: encoding/asn1@go1.25
    Fixed in: encoding/asn1@go1.25.2
    Example traces found:
      #1: cmd/device_init.go:148:46: cmd.doDI calls x509.CreateCertificateRequest, which calls asn1.Unmarshal

Vulnerability #7: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.25
    Fixed in: net/url@go1.25.2
    Example traces found:
      #1: cmd/device_init.go:205:21: cmd.doDI calls fdo.DI, which eventually calls url.JoinPath
      #2: cmd/root.go:40:15: cmd.Execute calls signal.Notify, which eventually calls url.Parse
      #3: cmd/device_init.go:258:39: cmd.validateDIFlags calls url.ParseRequestURI
      #4: cmd/device_init.go:205:21: cmd.doDI calls fdo.DI, which eventually calls url.URL.Parse

Vulnerability #8: GO-2025-4009
    Quadratic complexity when parsing some invalid inputs in encoding/pem
  More info: https://pkg.go.dev/vuln/GO-2025-4009
  Standard library
    Found in: encoding/pem@go1.25
    Fixed in: encoding/pem@go1.25.2
    Example traces found:
      #1: cmd/root.go:40:15: cmd.Execute calls signal.Notify, which eventually calls pem.Decode

Vulnerability #9: GO-2025-4008
    ALPN negotiation error contains attacker controlled information in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2025-4008
  Standard library
    Found in: crypto/tls@go1.25
    Fixed in: crypto/tls@go1.25.2
    Example traces found:
      #1: internal/tls/tls.go:60:25: tls.userAgentTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls tls.Conn.HandshakeContext
      #2: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls tls.Conn.Read
      #3: cmd/root.go:50:24: cmd.Execute calls cobra.Command.Execute, which eventually calls tls.Conn.Write
      #4: internal/tls/tls.go:60:25: tls.userAgentTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls tls.Dialer.DialContext

Vulnerability #10: GO-2025-4007
    Quadratic complexity when checking name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4007
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.3
    Example traces found:
      #1: cmd/root.go:40:15: cmd.Execute calls signal.Notify, which eventually calls x509.CertPool.AppendCertsFromPEM
      #2: internal/tpm_utils/tpm_nv.go:157:28: tpm_utils.TpmNVWrite calls tpm2.NVWrite.Execute, which eventually calls x509.Certificate.Verify
      #3: cmd/device_init.go:148:46: cmd.doDI calls x509.CreateCertificateRequest
      #4: cmd/root.go:40:15: cmd.Execute calls signal.Notify, which eventually calls x509.ParseCertificate
      #5: cmd/device_init.go:155:42: cmd.doDI calls x509.ParseCertificateRequest
      #6: cmd/device_init.go:205:21: cmd.doDI calls fdo.DI, which eventually calls x509.ParsePKIXPublicKey

Your code is affected by 10 vulnerabilities from the Go standard library.
```