### PR TITLE
chore: bump for 1.0.0 release

### DIFF
--- a/build/package/rpm/go-fdo-client.spec
+++ b/build/package/rpm/go-fdo-client.spec
@@ -12,7 +12,7 @@
 %global debug_package %{nil}
 %endif
 
-Version:        0.0.3
+Version:        1.0.0
 %gometa -L -f
 
 Name:           go-fdo-client


### PR DESCRIPTION
Prepare for the go-fdo-client 1.0.0 release.