### PR TITLE
ci: generate FDO server certs in E2E test setup

### DIFF
--- a/test/fmf/plans/e2e.fmf
+++ b/test/fmf/plans/e2e.fmf
@@ -25,6 +25,10 @@ prepare:
           go-fdo-server-owner \
           go-fdo-server-rendezvous
         dnf copr disable -y @fedora-iot/fedora-iot
+
+        # Generate FDO server certificates for E2E testing
+        echo "Generating FDO server certificates..."
+        sudo /usr/libexec/go-fdo-server/generate-go-fdo-server-certs.sh
 provision:
     how: virtual
     memory: 4096


### PR DESCRIPTION
E2E testing-farm tests were failing because FDO server services require certificates that weren't being generated. Add cert generation step to test preparation.