### PR TITLE
chore: remove legacy --download and --wget options

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -60,16 +60,13 @@ The onboarding configuration is under the `onboard` section:
 |-----|------|-------------|----------|
 | `kex` | string | Key exchange suite. Options: `DHKEXid14`, `DHKEXid15`, `ASYMKEX2048`, `ASYMKEX3072`, `ECDH256`, `ECDH384` | Yes |
 | `cipher` | string | Cipher suite for encryption. Options: `A128GCM`, `A192GCM`, `A256GCM`, `AES-CCM-64-128-128`, `AES-CCM-64-128-256`, `COSEAES128CBC`, `COSEAES128CTR`, `COSEAES256CBC`, `COSEAES256CTR` | No (default: `A128GCM`) |
-| `download` | string | Directory to download files into (FSIM disabled if empty) | No |
-| `echo-commands` | boolean | Echo all commands received to stdout (FSIM disabled if false) | No (default: false) |
+| `default-working-dir` | string | Default working directory for all FSIMs. The `fdo.command` module executes commands from this directory. The `fdo.download` and `fdo.wget` modules create temporary files in this directory and resolve relative file paths using it as the base. The `fdo.upload` module resolves relative file paths from this directory. Must be an absolute path to a writable directory. | No (default: current working directory) |
 | `enable-interop-test` | boolean | Enable FIDO Alliance interop test module | No (default: false) |
 | `insecure-tls` | boolean | Skip TLS certificate verification | No (default: false) |
 | `max-serviceinfo-size` | integer | Maximum service info size to receive (0-65535) | No (default: 1300) |
 | `allow-credential-reuse` | boolean | Allow credential reuse protocol during onboarding | No (default: false) |
 | `resale` | boolean | Perform resale/re-onboarding | No (default: false) |
 | `to2-retry-delay` | duration | Delay between failed TO2 attempts (e.g., `5s`, `1m`) | No (default: 0, disabled) |
-| `upload` | list of strings | Directories and files to upload from | No |
-| `wget-dir` | string | Directory for wget file operations (FSIM disabled if empty) | No |
 
 ## Configuration File Examples
 
@@ -89,18 +86,13 @@ device-init:
 onboard:
   kex: "ECDH384"
   cipher: "A256GCM"
-  download: "/tmp/downloads"
-  echo-commands: false
+  default-working-dir: "/var/fdo/working"
   enable-interop-test: false
   insecure-tls: false
   max-serviceinfo-size: 1300
   allow-credential-reuse: false
   resale: false
   to2-retry-delay: "5s"
-  upload:
-    - "/path/to/file1"
-    - "/path/to/dir1"
-  wget-dir: "/tmp/wget"
 ```
 
 ### TOML Configuration
@@ -119,16 +111,13 @@ insecure-tls = false
 [onboard]
 kex = "ECDH384"
 cipher = "A256GCM"
-download = "/tmp/downloads"
-echo-commands = false
+default-working-dir = "/var/fdo/working"
 enable-interop-test = false
 insecure-tls = false
 max-serviceinfo-size = 1300
 allow-credential-reuse = false
 resale = false
 to2-retry-delay = "5s"
-upload = ["/path/to/file1", "/path/to/dir1"]
-wget-dir = "/tmp/wget"
 ```
 
 ## Precedence Order

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Usage:
 Flags:
       --allow-credential-reuse     Allow credential reuse protocol during onboarding
       --cipher string              Name of cipher suite to use for encryption (see usage) (default "A128GCM")
-      --default-working-dir string Default working directory for all FSIMs (fdo.command, fdo.download, fdo.upload, fdo.wget)
-      --download string            fdo.download: override destination directory set by Owner server
+      --default-working-dir string Default working directory for all FSIMs (fdo.command, fdo.download, fdo.upload, fdo.wget) (default current working directory)
   -h, --help                       help for onboard
       --insecure-tls               Skip TLS certificate verification
       --kex string                 Name of cipher suite to use for key exchange (see usage)
@@ -84,7 +83,6 @@ Flags:
       --resale                     Perform resale
       --rv-only                    Perform TO1 then stop
       --to2-retry-delay duration   Delay between failed TO2 attempts when trying multiple Owner URLs from same RV directive (0=disabled)
-      --wget-dir string            fdo.wget: override destination directory set by Owner server
 
 Global Flags:
       --blob string   File path of device credential blob
@@ -131,10 +129,10 @@ The `onboard` command implements an infinite retry loop that continues attemptin
 
 The `onboard` command supports the following FDO Service Modules that can be invoked by the FDO Owner server during device onboarding:
 
-- **fdo.command**: The `fdo.command` module provides the functionality that allows the FDO Owner server to execute arbitrary shell commands on the device.
-- **fdo.download**: The `fdo.download` module provides the functionality to download a binary file from the FDO Owner server to the device.
-- **fdo.upload**: The `fdo.upload` module provides the functionality to transfer a binary file from the device to the FDO Owner server. Supports both absolute and relative file paths, with relative paths resolved from the default working directory.
-- **fdo.wget**: The `fdo.wget` module provides the functionality to transfer a binary file from an HTTP server to the device via a network.
+- **fdo.command**: The `fdo.command` module provides the functionality that allows the FDO Owner server to execute arbitrary shell commands on the device. Commands are executed from the default working directory.
+- **fdo.download**: The `fdo.download` module provides the functionality to download a binary file from the FDO Owner server to the device. Temporary files are created in the default working directory. Relative file paths from the Owner server are resolved using the default working directory as the base; absolute paths are used as-is.
+- **fdo.upload**: The `fdo.upload` module provides the functionality to transfer a binary file from the device to the FDO Owner server. Relative file paths are resolved from the default working directory; absolute paths are used as-is.
+- **fdo.wget**: The `fdo.wget` module provides the functionality to transfer a binary file from an HTTP server to the device via a network. Temporary files are created in the default working directory. Relative file paths from the Owner server are resolved using the default working directory as the base; absolute paths are used as-is.
 
 Please refer to the FSIM module definition [documentation](https://github.com/fido-alliance/fdo-sim) for further details. By default all Service Modules are available for use by the FDO Owner server during onboarding. Refer to the `onboard` command help text for additional service module configuration options. Refer to the FDO Owner server [documentation](https://github.com/fido-device-onboard/go-fdo-server) for server-side service module configuration details.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,15 +53,12 @@ type OnboardConfig struct {
 	Kex                  string        `mapstructure:"kex"`
 	Cipher               string        `mapstructure:"cipher"`
 	DefaultWorkingDir    string        `mapstructure:"default-working-dir"`
-	Download             string        `mapstructure:"download"`
-	EchoCommands         bool          `mapstructure:"echo-commands"`
 	EnableInteropTest    bool          `mapstructure:"enable-interop-test"`
 	InsecureTLS          bool          `mapstructure:"insecure-tls"`
 	MaxServiceInfoSize   int           `mapstructure:"max-serviceinfo-size"`
 	AllowCredentialReuse bool          `mapstructure:"allow-credential-reuse"`
 	Resale               bool          `mapstructure:"resale"`
 	TO2RetryDelay        time.Duration `mapstructure:"to2-retry-delay"`
-	WgetDir              string        `mapstructure:"wget-dir"`
 }
 
 type DeviceInitClientConfig struct {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -415,7 +415,6 @@ key = "ec384"
 [onboard]
 kex = "ECDH384"
 cipher = "A256GCM"
-echo-commands = true
 insecure-tls = true
 max-serviceinfo-size = 2000
 allow-credential-reuse = true
@@ -427,7 +426,6 @@ key: ec384
 onboard:
   kex: ECDH384
   cipher: A256GCM
-  echo-commands: true
   insecure-tls: true
   max-serviceinfo-size: 2000
   allow-credential-reuse: true
@@ -441,9 +439,6 @@ onboard:
 	}
 	if got, want := o.Cipher, "A256GCM"; got != want {
 		t.Errorf("Cipher = %q, want %q", got, want)
-	}
-	if got, want := o.EchoCommands, true; got != want {
-		t.Errorf("EchoCommands = %v, want %v", got, want)
 	}
 	if got, want := o.MaxServiceInfoSize, 2000; got != want {
 		t.Errorf("MaxServiceInfoSize = %d, want %d", got, want)
@@ -561,7 +556,7 @@ onboard:
 
 	runTestBothFormats(t, "", onboardCmd, toml, yaml, false,
 		"--blob", "cli.bin", "--key", "ec384", "--kex", "ECDH384", "--cipher", "A256GCM",
-		"--max-serviceinfo-size", "2000", "--echo-commands", "--resale")
+		"--max-serviceinfo-size", "2000", "--resale")
 
 	o := capturedConfig.OnboardConfig
 	checks := []struct {
@@ -573,7 +568,6 @@ onboard:
 		{"Kex", o.Kex, "ECDH384"},
 		{"Cipher", o.Cipher, "A256GCM"},
 		{"MaxServiceInfoSize", o.MaxServiceInfoSize, 2000},
-		{"EchoCommands", o.EchoCommands, true},
 		{"Resale", o.Resale, true},
 	}
 
@@ -639,8 +633,8 @@ onboard:
 	stubRunE(t, onboardCmd)
 	path := writeConfig(t, yaml, "yaml")
 
-	// CLI provides echo-commands and max-serviceinfo-size, but NOT cipher, insecure-tls, resale
-	rootCmd.SetArgs([]string{"onboard", "--config", path, "--echo-commands", "--max-serviceinfo-size", "2000"})
+	// CLI provides max-serviceinfo-size, but NOT cipher, insecure-tls, resale
+	rootCmd.SetArgs([]string{"onboard", "--config", path, "--max-serviceinfo-size", "2000"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -649,9 +643,6 @@ onboard:
 	o := capturedConfig.OnboardConfig
 
 	// Verify CLI values
-	if got, want := o.EchoCommands, true; got != want {
-		t.Errorf("EchoCommands = %v, want %v (from CLI)", got, want)
-	}
 	if got, want := o.MaxServiceInfoSize, 2000; got != want {
 		t.Errorf("MaxServiceInfoSize = %d, want %d (from CLI)", got, want)
 	}
@@ -750,9 +741,6 @@ onboard:
 	if got, want := o.InsecureTLS, false; got != want {
 		t.Errorf("InsecureTLS = %v, want %v", got, want)
 	}
-	if got, want := o.EchoCommands, false; got != want {
-		t.Errorf("EchoCommands = %v, want %v", got, want)
-	}
 	if got, want := o.Resale, false; got != want {
 		t.Errorf("Resale = %v, want %v", got, want)
 	}
@@ -808,12 +796,9 @@ func TestOnboard_DirectoryValidation(t *testing.T) {
 		value   string
 		wantErr bool
 	}{
-		{"valid download", "download", validDir, false},
-		{"invalid download", "download", "/nonexistent", true},
-		{"valid wget-dir", "wget-dir", validDir, false},
-		{"invalid wget-dir", "wget-dir", "/nonexistent", true},
 		{"valid default-working-dir", "default-working-dir", validDir, false},
 		{"invalid default-working-dir", "default-working-dir", "/nonexistent", true},
+		{"relative default-working-dir", "default-working-dir", "its/relative", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -130,8 +130,6 @@ func onboardCmdInit() {
 
 	onboardCmd.Flags().Bool("allow-credential-reuse", false, "Allow credential reuse protocol during onboarding")
 	onboardCmd.Flags().String("cipher", "A128GCM", "Name of cipher suite to use for encryption (see usage)")
-	onboardCmd.Flags().String("download", "", "fdo.download: override destination directory set by Owner server")
-	onboardCmd.Flags().Bool("echo-commands", false, "Echo all commands received to stdout (FSIM disabled if false)")
 	onboardCmd.Flags().Bool("enable-interop-test", false, "Enable FIDO Alliance interop test module (fsim.Interop)")
 	onboardCmd.Flags().String("kex", "", "Name of cipher suite to use for key exchange (see usage)")
 	onboardCmd.Flags().Bool("insecure-tls", false, "Skip TLS certificate verification")
@@ -139,7 +137,6 @@ func onboardCmdInit() {
 	onboardCmd.Flags().Bool("resale", false, "Perform resale")
 	onboardCmd.Flags().Duration("to2-retry-delay", 0, "Delay between failed TO2 attempts when trying multiple Owner URLs from same RV directive (0=disabled)")
 	onboardCmd.Flags().String("default-working-dir", currentDir, "Default working directory for all FSIMs (fdo.command, fdo.download, fdo.upload, fdo.wget)")
-	onboardCmd.Flags().String("wget-dir", "", "fdo.wget: override destination directory set by Owner server")
 }
 
 func init() {
@@ -375,9 +372,9 @@ func transferOwnership(ctx context.Context, rvInfo [][]protocol.RvInstruction, c
 
 // initializeFSIMs creates and configures all FDO Service Info Modules (FSIMs).
 // All standard FSIMs (fdo.command, fdo.download, fdo.upload, fdo.wget) are enabled
-// by default using go-fdo library defaults. The CLI parameters allow customization
-// of the default behavior. Uses a common default directory for FIDO Alliance compliance.
-func initializeFSIMs(dlDir, wgetDir, defaultWorkingDir string, enableInteropTest bool) map[string]serviceinfo.DeviceModule {
+// by default. Temporary files are created relative to defaultWorkingDir, and
+// relative file names in download/wget are resolved using defaultWorkingDir as the base.
+func initializeFSIMs(defaultWorkingDir string, enableInteropTest bool) map[string]serviceinfo.DeviceModule {
 	fsims := map[string]serviceinfo.DeviceModule{}
 	if enableInteropTest {
 		fsims["fido_alliance"] = &fsim.Interop{}
@@ -387,30 +384,24 @@ func initializeFSIMs(dlDir, wgetDir, defaultWorkingDir string, enableInteropTest
 	// that allows the user to explicitly select which FSIMs should be
 	// enabled.
 
-	// Use service module defaults provided by the go-fdo library. Use the CLI options
-	// to customize the default behavior.
-
 	fsims["fdo.command"] = &fsim.Command{}
 
-	// fdo.download: enable error output. Use --download to force downloaded files into a specific
-	// local directory, otherwise allow the owner server to control where the file is stored on
-	// the local device
+	// fdo.download: create temporary files in defaultWorkingDir.
+	// NameToPath converts relative paths to absolute using defaultWorkingDir as the base.
+	// Absolute paths are used as-is.
 	dlFSIM := &fsim.Download{
 		ErrorLog: &slogErrorWriter{},
 		Rename:   moveFile,
-	}
-	if dlDir != "" {
-		dlFSIM.CreateTemp = func() (*os.File, error) {
-			tmpFile, err := os.CreateTemp(dlDir, ".fdo.download_*")
-			if err != nil {
-				return nil, err
-			}
-			return tmpFile, nil
-		}
-		dlFSIM.NameToPath = func(name string) string {
+		CreateTemp: func() (*os.File, error) {
+			return os.CreateTemp(defaultWorkingDir, ".fdo.download_*")
+		},
+		NameToPath: func(name string) string {
 			cleanName := filepath.Clean(name)
-			return filepath.Join(dlDir, filepath.Base(cleanName))
-		}
+			if filepath.IsAbs(cleanName) {
+				return cleanName
+			}
+			return filepath.Join(defaultWorkingDir, cleanName)
+		},
 	}
 	fsims["fdo.download"] = dlFSIM
 
@@ -423,23 +414,21 @@ func initializeFSIMs(dlDir, wgetDir, defaultWorkingDir string, enableInteropTest
 		},
 	}
 
-	// fdo.wget: use --wget-dir to force downloaded files into a specific local directory,
-	// otherwise allow the owner server to control where the file is stored on the device
+	// fdo.wget: create temporary files in defaultWorkingDir.
+	// NameToPath converts relative paths to absolute using defaultWorkingDir as the base.
+	// Absolute paths are used as-is.
 	wgetFSIM := &fsim.Wget{
 		Rename: moveFile,
-	}
-	if wgetDir != "" {
-		wgetFSIM.CreateTemp = func() (*os.File, error) {
-			tmpFile, err := os.CreateTemp(wgetDir, ".fdo.wget_*")
-			if err != nil {
-				return nil, err
-			}
-			return tmpFile, nil
-		}
-		wgetFSIM.NameToPath = func(name string) string {
+		CreateTemp: func() (*os.File, error) {
+			return os.CreateTemp(defaultWorkingDir, ".fdo.wget_*")
+		},
+		NameToPath: func(name string) string {
 			cleanName := filepath.Clean(name)
-			return filepath.Join(wgetDir, filepath.Base(cleanName))
-		}
+			if filepath.IsAbs(cleanName) {
+				return cleanName
+			}
+			return filepath.Join(defaultWorkingDir, cleanName)
+		},
 	}
 	fsims["fdo.wget"] = wgetFSIM
 
@@ -447,7 +436,29 @@ func initializeFSIMs(dlDir, wgetDir, defaultWorkingDir string, enableInteropTest
 }
 
 func transferOwnership2(ctx context.Context, transport fdo.Transport, to1d *cose.Sign1[protocol.To1d, []byte], conf fdo.TO2Config) (*fdo.DeviceCredential, error) {
-	conf.DeviceModules = initializeFSIMs(onboardConfig.Onboard.Download, onboardConfig.Onboard.WgetDir, onboardConfig.Onboard.DefaultWorkingDir, onboardConfig.Onboard.EnableInteropTest)
+	conf.DeviceModules = initializeFSIMs(onboardConfig.Onboard.DefaultWorkingDir, onboardConfig.Onboard.EnableInteropTest)
+
+	// Change to default working directory before TO2 so that the fdo.command FSIM operates
+	// in the same working directory as the file-oriented FSIMs (fdo.download, fdo.upload, fdo.wget).
+	// Restore the original directory after TO2.
+	defaultDir := onboardConfig.Onboard.DefaultWorkingDir
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	if currentDir != defaultDir {
+		if err := os.Chdir(defaultDir); err != nil {
+			return nil, fmt.Errorf("failed to change to default working directory %s: %w", defaultDir, err)
+		}
+		slog.Debug("Changed working directory for TO2", "dir", defaultDir)
+		defer func() {
+			if err := os.Chdir(currentDir); err != nil {
+				slog.Error("Failed to restore working directory", "dir", currentDir, "error", err)
+			}
+		}()
+	}
+
 	return fdo.TO2(ctx, transport, to1d, conf)
 }
 
@@ -565,10 +576,6 @@ func (o *OnboardClientConfig) validate() error {
 		return fmt.Errorf("invalid cipher suite: %s", o.Onboard.Cipher)
 	}
 
-	if o.Onboard.Download != "" && (!isValidPath(o.Onboard.Download) || !fileExists(o.Onboard.Download)) {
-		return fmt.Errorf("invalid download directory: %s", o.Onboard.Download)
-	}
-
 	if !slices.Contains(validKexSuites, o.Onboard.Kex) {
 		return fmt.Errorf("invalid key exchange suite: '%s', options [%s]",
 			o.Onboard.Kex, strings.Join(validKexSuites, ", "))
@@ -576,10 +583,6 @@ func (o *OnboardClientConfig) validate() error {
 
 	if o.Onboard.MaxServiceInfoSize < 0 || o.Onboard.MaxServiceInfoSize > math.MaxUint16 {
 		return fmt.Errorf("max-serviceinfo-size must be between 0 and %d", math.MaxUint16)
-	}
-
-	if o.Onboard.WgetDir != "" && (!isValidPath(o.Onboard.WgetDir) || !fileExists(o.Onboard.WgetDir)) {
-		return fmt.Errorf("invalid wget directory: %s", o.Onboard.WgetDir)
 	}
 
 	return nil

--- a/cmd/onboard_test.go
+++ b/cmd/onboard_test.go
@@ -15,8 +15,8 @@ import (
 // TestFSIMsEnabledByDefault verifies that all standard FSIMs are enabled
 // by default without any CLI flags
 func TestFSIMsEnabledByDefault(t *testing.T) {
-	// Initialize with empty parameters (no CLI flags)
-	fsims := initializeFSIMs("", "", "/tmp/fdo-test-default", false)
+	tempDir := t.TempDir()
+	fsims := initializeFSIMs(tempDir, false)
 
 	// Verify all expected standard modules are present
 	expectedModules := []string{"fdo.command", "fdo.download", "fdo.upload", "fdo.wget"}
@@ -35,7 +35,8 @@ func TestFSIMsEnabledByDefault(t *testing.T) {
 // TestInteropModuleNotEnabledByDefault verifies that the interop test module
 // is NOT enabled when the flag is false
 func TestInteropModuleNotEnabledByDefault(t *testing.T) {
-	fsims := initializeFSIMs("", "", "/tmp/fdo-test-default", false)
+	tempDir := t.TempDir()
+	fsims := initializeFSIMs(tempDir, false)
 
 	if _, exists := fsims["fido_alliance"]; exists {
 		t.Error("fido_alliance module should not be enabled by default (when enableInteropTest is false)")
@@ -45,7 +46,8 @@ func TestInteropModuleNotEnabledByDefault(t *testing.T) {
 // TestInteropModuleEnabledWithFlag verifies that the interop test module
 // IS enabled when the flag is true
 func TestInteropModuleEnabledWithFlag(t *testing.T) {
-	fsims := initializeFSIMs("", "", "/tmp/fdo-test-default", true)
+	tempDir := t.TempDir()
+	fsims := initializeFSIMs(tempDir, true)
 
 	if _, exists := fsims["fido_alliance"]; !exists {
 		t.Error("fido_alliance module should be enabled when enableInteropTest is true")
@@ -57,10 +59,11 @@ func TestInteropModuleEnabledWithFlag(t *testing.T) {
 	}
 }
 
-// TestDownloadModuleWithoutFlag verifies that download FSIM uses library defaults
-// when no --download flag is provided
-func TestDownloadModuleWithoutFlag(t *testing.T) {
-	fsims := initializeFSIMs("", "", "/tmp/fdo-test-default", false)
+// TestDownloadModuleCallbacks verifies that download FSIM always has
+// CreateTemp and NameToPath callbacks configured
+func TestDownloadModuleCallbacks(t *testing.T) {
+	tempDir := t.TempDir()
+	fsims := initializeFSIMs(tempDir, false)
 
 	dlFSIM, ok := fsims["fdo.download"].(*fsim.Download)
 	if !ok {
@@ -72,46 +75,24 @@ func TestDownloadModuleWithoutFlag(t *testing.T) {
 		t.Error("ErrorLog should be configured for download module")
 	}
 
-	// Verify no custom callbacks are set (library defaults should be used)
-	if dlFSIM.CreateTemp != nil {
-		t.Error("CreateTemp should be nil when --download flag is not provided (use library defaults)")
-	}
-	if dlFSIM.NameToPath != nil {
-		t.Error("NameToPath should be nil when --download flag is not provided (use library defaults)")
-	}
-}
-
-// TestDownloadModuleWithFlag verifies that download FSIM uses custom path handling
-// when --download flag is provided
-func TestDownloadModuleWithFlag(t *testing.T) {
-	// Create a temporary test directory
-	tempDir := t.TempDir()
-
-	fsims := initializeFSIMs(tempDir, "", "/tmp/fdo-test-default", false)
-
-	dlFSIM, ok := fsims["fdo.download"].(*fsim.Download)
-	if !ok {
-		t.Fatal("fdo.download module is not of type *fsim.Download")
-	}
-
-	// Verify custom callbacks are set
+	// CreateTemp and NameToPath should always be set
 	if dlFSIM.CreateTemp == nil {
-		t.Error("CreateTemp should be set when --download flag is provided")
+		t.Error("CreateTemp should always be set")
 	}
 	if dlFSIM.NameToPath == nil {
-		t.Error("NameToPath should be set when --download flag is provided")
+		t.Error("NameToPath should always be set")
 	}
 }
 
 // TestDownloadCreateTempFunction verifies that CreateTemp creates files in the
-// specified directory with the correct pattern
+// default working directory with the correct pattern
 func TestDownloadCreateTempFunction(t *testing.T) {
 	tempDir := t.TempDir()
 
-	fsims := initializeFSIMs(tempDir, "", "/tmp/fdo-test-default", false)
+	fsims := initializeFSIMs(tempDir, false)
 	dlFSIM := fsims["fdo.download"].(*fsim.Download)
 
-	// Test CreateTemp creates files in the specified directory
+	// Test CreateTemp creates files in the default working directory
 	tempFile, err := dlFSIM.CreateTemp()
 	if err != nil {
 		t.Fatalf("CreateTemp failed: %v", err)
@@ -119,9 +100,9 @@ func TestDownloadCreateTempFunction(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	// Verify file is in the specified directory
+	// Verify file is in the default working directory
 	if !strings.HasPrefix(tempFile.Name(), tempDir) {
-		t.Errorf("Temp file %s not created in specified directory %s", tempFile.Name(), tempDir)
+		t.Errorf("Temp file %s not created in default working directory %s", tempFile.Name(), tempDir)
 	}
 
 	// Verify file matches expected pattern .fdo.download_*
@@ -131,12 +112,12 @@ func TestDownloadCreateTempFunction(t *testing.T) {
 	}
 }
 
-// TestDownloadNameToPathFunction verifies that NameToPath forces files into
-// the specified directory and uses basename only (security feature)
+// TestDownloadNameToPathFunction verifies that NameToPath converts relative
+// paths to absolute using defaultWorkingDir, and passes absolute paths through
 func TestDownloadNameToPathFunction(t *testing.T) {
 	tempDir := t.TempDir()
 
-	fsims := initializeFSIMs(tempDir, "", "/tmp/fdo-test-default", false)
+	fsims := initializeFSIMs(tempDir, false)
 	dlFSIM := fsims["fdo.download"].(*fsim.Download)
 
 	testCases := []struct {
@@ -145,29 +126,24 @@ func TestDownloadNameToPathFunction(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "absolute path with directory traversal",
+			name:     "absolute path is preserved",
 			input:    "/etc/passwd",
-			expected: filepath.Join(tempDir, "passwd"),
+			expected: "/etc/passwd",
 		},
 		{
-			name:     "relative path with parent directory traversal",
-			input:    "../../../etc/shadow",
-			expected: filepath.Join(tempDir, "shadow"),
-		},
-		{
-			name:     "path with subdirectory",
-			input:    "subdir/file.txt",
-			expected: filepath.Join(tempDir, "file.txt"),
-		},
-		{
-			name:     "simple filename",
+			name:     "simple filename becomes absolute",
 			input:    "file.txt",
 			expected: filepath.Join(tempDir, "file.txt"),
 		},
 		{
-			name:     "path with multiple levels",
+			name:     "relative path with subdirectory",
+			input:    "subdir/file.txt",
+			expected: filepath.Join(tempDir, "subdir/file.txt"),
+		},
+		{
+			name:     "absolute path with multiple levels",
 			input:    "/var/log/messages/app.log",
-			expected: filepath.Join(tempDir, "app.log"),
+			expected: "/var/log/messages/app.log",
 		},
 	}
 
@@ -181,55 +157,35 @@ func TestDownloadNameToPathFunction(t *testing.T) {
 	}
 }
 
-// TestWgetModuleWithoutFlag verifies that wget FSIM uses library defaults
-// when no --wget-dir flag is provided
-func TestWgetModuleWithoutFlag(t *testing.T) {
-	fsims := initializeFSIMs("", "", "/tmp/fdo-test-default", false)
-
-	wgetFSIM, ok := fsims["fdo.wget"].(*fsim.Wget)
-	if !ok {
-		t.Fatal("fdo.wget module is not of type *fsim.Wget")
-	}
-
-	// Verify no custom callbacks are set (library defaults should be used)
-	if wgetFSIM.CreateTemp != nil {
-		t.Error("CreateTemp should be nil when --wget-dir flag is not provided (use library defaults)")
-	}
-	if wgetFSIM.NameToPath != nil {
-		t.Error("NameToPath should be nil when --wget-dir flag is not provided (use library defaults)")
-	}
-}
-
-// TestWgetModuleWithFlag verifies that wget FSIM uses custom path handling
-// when --wget-dir flag is provided
-func TestWgetModuleWithFlag(t *testing.T) {
+// TestWgetModuleCallbacks verifies that wget FSIM always has
+// CreateTemp and NameToPath callbacks configured
+func TestWgetModuleCallbacks(t *testing.T) {
 	tempDir := t.TempDir()
-
-	fsims := initializeFSIMs("", tempDir, "/tmp/fdo-test-default", false)
+	fsims := initializeFSIMs(tempDir, false)
 
 	wgetFSIM, ok := fsims["fdo.wget"].(*fsim.Wget)
 	if !ok {
 		t.Fatal("fdo.wget module is not of type *fsim.Wget")
 	}
 
-	// Verify custom callbacks are set
+	// CreateTemp and NameToPath should always be set
 	if wgetFSIM.CreateTemp == nil {
-		t.Error("CreateTemp should be set when --wget-dir flag is provided")
+		t.Error("CreateTemp should always be set")
 	}
 	if wgetFSIM.NameToPath == nil {
-		t.Error("NameToPath should be set when --wget-dir flag is provided")
+		t.Error("NameToPath should always be set")
 	}
 }
 
-// TestWgetCreateTempFunction verifies that CreateTemp creates files with
-// the correct pattern for wget module
+// TestWgetCreateTempFunction verifies that CreateTemp creates files in the
+// default working directory with the correct pattern
 func TestWgetCreateTempFunction(t *testing.T) {
 	tempDir := t.TempDir()
 
-	fsims := initializeFSIMs("", tempDir, "/tmp/fdo-test-default", false)
+	fsims := initializeFSIMs(tempDir, false)
 	wgetFSIM := fsims["fdo.wget"].(*fsim.Wget)
 
-	// Test CreateTemp creates files in the specified directory
+	// Test CreateTemp creates files in the default working directory
 	tempFile, err := wgetFSIM.CreateTemp()
 	if err != nil {
 		t.Fatalf("CreateTemp failed: %v", err)
@@ -237,9 +193,9 @@ func TestWgetCreateTempFunction(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	// Verify file is in the specified directory
+	// Verify file is in the default working directory
 	if !strings.HasPrefix(tempFile.Name(), tempDir) {
-		t.Errorf("Temp file %s not created in specified directory %s", tempFile.Name(), tempDir)
+		t.Errorf("Temp file %s not created in default working directory %s", tempFile.Name(), tempDir)
 	}
 
 	// Verify file matches expected pattern .fdo.wget_*
@@ -249,12 +205,12 @@ func TestWgetCreateTempFunction(t *testing.T) {
 	}
 }
 
-// TestWgetNameToPathFunction verifies that wget NameToPath has the same
-// security behavior as download (basename only)
+// TestWgetNameToPathFunction verifies that wget NameToPath converts relative
+// paths to absolute using defaultWorkingDir, and passes absolute paths through
 func TestWgetNameToPathFunction(t *testing.T) {
 	tempDir := t.TempDir()
 
-	fsims := initializeFSIMs("", tempDir, "/tmp/fdo-test-default", false)
+	fsims := initializeFSIMs(tempDir, false)
 	wgetFSIM := fsims["fdo.wget"].(*fsim.Wget)
 
 	testCases := []struct {
@@ -263,19 +219,19 @@ func TestWgetNameToPathFunction(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "absolute path",
-			input:    "/usr/bin/malicious",
-			expected: filepath.Join(tempDir, "malicious"),
+			name:     "absolute path is preserved",
+			input:    "/usr/bin/somefile",
+			expected: "/usr/bin/somefile",
 		},
 		{
-			name:     "directory traversal attempt",
-			input:    "../../etc/passwd",
-			expected: filepath.Join(tempDir, "passwd"),
+			name:     "relative path becomes absolute",
+			input:    "downloads/photo.jpg",
+			expected: filepath.Join(tempDir, "downloads/photo.jpg"),
 		},
 		{
-			name:     "nested path",
-			input:    "downloads/images/photo.jpg",
-			expected: filepath.Join(tempDir, "photo.jpg"),
+			name:     "simple filename becomes absolute",
+			input:    "file.txt",
+			expected: filepath.Join(tempDir, "file.txt"),
 		},
 	}
 
@@ -298,7 +254,7 @@ func TestUploadModuleUsesDefaultDir(t *testing.T) {
 		t.Fatalf("Failed to get current working directory: %v", err)
 	}
 
-	fsims := initializeFSIMs("", "", defaultWorkingDir, false)
+	fsims := initializeFSIMs(defaultWorkingDir, false)
 
 	uploadFSIM, ok := fsims["fdo.upload"].(*fsim.Upload)
 	if !ok {
@@ -389,22 +345,16 @@ func TestWorkingDirFS(t *testing.T) {
 func TestCommandModuleAlwaysEnabled(t *testing.T) {
 	testCases := []struct {
 		name              string
-		dlDir             string
-		wgetDir           string
 		defaultWorkingDir string
 		enableInteropTest bool
 	}{
 		{
 			name:              "no flags",
-			dlDir:             "",
-			wgetDir:           "",
 			defaultWorkingDir: "/tmp/fdo-test-default",
 			enableInteropTest: false,
 		},
 		{
-			name:              "all flags set",
-			dlDir:             "/tmp/dl",
-			wgetDir:           "/tmp/wget",
+			name:              "interop enabled",
 			defaultWorkingDir: "/tmp/default",
 			enableInteropTest: true,
 		},
@@ -412,7 +362,7 @@ func TestCommandModuleAlwaysEnabled(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fsims := initializeFSIMs(tc.dlDir, tc.wgetDir, tc.defaultWorkingDir, tc.enableInteropTest)
+			fsims := initializeFSIMs(tc.defaultWorkingDir, tc.enableInteropTest)
 
 			if _, exists := fsims["fdo.command"]; !exists {
 				t.Error("fdo.command module should always be enabled")


### PR DESCRIPTION
Updates the fdo.download and fdo.wget FSIM configuration to use the default working directory configuration value.

Sets the working directory when running TO2 to ensure that fdo.command executes within it.
