### PR TITLE
fix: generate go-fdo-server certs

### DIFF
--- a/test/fmf/tests/test-onboarding.sh
+++ b/test/fmf/tests/test-onboarding.sh
@@ -71,14 +71,14 @@ if ! rpm -q go-fdo-client &>/dev/null; then
     exit 1
 fi
 
-if [[ -n "${PACKIT_COPR_RPMS}" ]]; then
-    log_info "Expected RPMs:  ${PACKIT_COPR_RPMS}"
+if [[ -n "${PACKIT_COPR_RPMS:-}" ]]; then
+    log_info "Expected RPMs:  ${PACKIT_COPR_RPMS:-}"
 fi
 CLIENT_PKG=$(rpm -q --qf "%{nvr}.%{arch}" go-fdo-client)
 log_info "Installed RPMs: ${CLIENT_PKG}"
 
 # Verify the installed package is from the PR build
-if [[ -n "${PACKIT_COPR_RPMS}" && ! "${PACKIT_COPR_RPMS}" =~ ${CLIENT_PKG} ]]; then
+if [[ -n "${PACKIT_COPR_RPMS:-}" && ! "${PACKIT_COPR_RPMS:-}" =~ ${CLIENT_PKG} ]]; then
     log_error "Package version does not appear to be from PR build"
     log_error "This suggests the PR artifact was replaced by a stable version"
     exit 1
@@ -119,6 +119,9 @@ log_info "go-fdo-client help menu is accessible"
 # Create test directory
 mkdir -p /tmp/fdo-test
 cd /tmp/fdo-test
+
+# Generate go-fdo-server certs
+source "/usr/libexec/go-fdo-server/generate-go-fdo-server-certs.sh"
 
 # Start FDO services
 log_info "Setting up FDO server environment..."

--- a/test/fmf/tests/test-retry-loop.sh
+++ b/test/fmf/tests/test-retry-loop.sh
@@ -286,6 +286,10 @@ run_test() {
     set_hostname owner 127.0.0.1
 
     verify_fdo_packages || exit 1
+
+    # Generate go-fdo-server certs
+    source "/usr/libexec/go-fdo-server/generate-go-fdo-server-certs.sh"
+
     start_fdo_services || exit 1
 
     # Run all test scenarios (continue even if one fails to see all results)


### PR DESCRIPTION
This PR is to fix CI errors that caused by changes in go-fdo-server, need to manually generate certificate after go-fdo-server installation.