### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Download PR metadata
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: pr-metadata

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run tests with coverage
         run: make test-coverage
 
       - name: Download base coverage breakdown
         id: download-main-breakdown
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v17
         with:
           branch: main
           workflow_conclusion: success
@@ -52,13 +52,13 @@ jobs:
 
       - name: Upload PR metadata
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-metadata
           path: pr-metadata/
 
       - name: Upload coverage breakdown
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: github.ref_name == 'main'
         with:
           name: main.breakdown
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: test/coverage/coverage.html


### PR DESCRIPTION
### What
Update GitHub Actions in coverage workflows to their latest major versions.

### Why
Several actions were outdated.

### Changes
- `actions/download-artifact` v4 → v8
- `actions/setup-go` v5 → v6
- `actions/checkout` v4 → v6
- `dawidd6/action-download-artifact` v6 → v17
- `actions/upload-artifact` v4 → v7