### PR TITLE
fix: strip date from generated man pages for reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,14 @@ vet:
 .PHONY: docs
 docs: man cli
 
+# Strip the date from generated man pages to keep them deterministic.
+# See https://github.com/fido-device-onboard/go-fdo-client/issues/113
 .PHONY: man
 man:
-	go run ./internal/tools/docgen -format man
+	SOURCE_DATE_EPOCH=0 go run ./internal/tools/docgen -format man
+	for f in docs/man/*.1; do \
+		sed 's/\(\.TH "[^"]*" "[^"]*"\) "[^"]*"/\1/' "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; \
+	done
 
 .PHONY: cli
 cli:

--- a/docs/man/go-fdo-client-device-init.1
+++ b/docs/man/go-fdo-client-device-init.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-CLIENT-DEVICE-INIT" "1" "Apr 2026" "go-fdo-client" "Go FDO Client"
+.TH "GO-FDO-CLIENT-DEVICE-INIT" "1" "go-fdo-client" "Go FDO Client"
 
 .SH NAME
 go-fdo-client-device-init - Run device initialization (DI)

--- a/docs/man/go-fdo-client-onboard.1
+++ b/docs/man/go-fdo-client-onboard.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-CLIENT-ONBOARD" "1" "Apr 2026" "go-fdo-client" "Go FDO Client"
+.TH "GO-FDO-CLIENT-ONBOARD" "1" "go-fdo-client" "Go FDO Client"
 
 .SH NAME
 go-fdo-client-onboard - Run FDO TO1 and TO2 onboarding

--- a/docs/man/go-fdo-client-print.1
+++ b/docs/man/go-fdo-client-print.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-CLIENT-PRINT" "1" "Apr 2026" "go-fdo-client" "Go FDO Client"
+.TH "GO-FDO-CLIENT-PRINT" "1" "go-fdo-client" "Go FDO Client"
 
 .SH NAME
 go-fdo-client-print - Print device credentials

--- a/docs/man/go-fdo-client.1
+++ b/docs/man/go-fdo-client.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-CLIENT" "1" "Apr 2026" "go-fdo-client" "Go FDO Client"
+.TH "GO-FDO-CLIENT" "1" "go-fdo-client" "Go FDO Client"
 
 .SH NAME
 go-fdo-client - FIDO Device Onboard (FDO) client


### PR DESCRIPTION
The cobra doc library embeds the current month/year into the .TH directive, causing man pages to change monthly and break CI's source-tree-unchanged check. Use SOURCE_DATE_EPOCH=0 and sed to remove the date field entirely.

Closes: #113

Assisted-by: Claude:claude-opus-4-6