### PR TITLE
chore: bump Go version to 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache 2.0
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /go/src/app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Prerequisites
 
-- Go 1.25.0 or later
+- Go 1.26 or later
 - A Go module initialized with `go mod init`
 
 ## Building the Client Application

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/fido-device-onboard/go-fdo-client
 
-// TODO: Upgrade to Go 1.25.8 or later to resolve GO-2026-4601 and GO-2026-4602.
-go 1.25.7
+go 1.26
 
 require (
 	github.com/fido-device-onboard/go-fdo v0.0.0-20260204145003-2d3d7c734680


### PR DESCRIPTION
### What
Bump Go from `1.25.7` to `1.26`.

### Why
Align with the Go version used in the `go-fdo-server` repository and resolve the following vulnerabilities:

- [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971)
- [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947)
- [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946)
- [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918)
- [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870)
- [GO-2026-4602](https://pkg.go.dev/vuln/GO-2026-4602)
- [GO-2026-4601](https://pkg.go.dev/vuln/GO-2026-4601)

Assisted-by: Claude (claude-opus-4-6)