### PR TITLE
ci: point Packit test jobs to go-fdo-ci for FMF test definitions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -123,6 +123,11 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: e2e-fedora
+    # Track main to always use the latest shared test definitions from go-fdo-ci
+    <<: &fmf_source
+      fmf_url: https://github.com/fido-device-onboard/go-fdo-ci
+      fmf_ref: main
+      use_target_repo_for_fmf_url: true
     tmt_plan: test/fmf/plans/e2e
     packages: [go-fdo-client-fedora]
     targets: *copr_fedora_targets
@@ -130,6 +135,7 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: bootc-fedora
+    <<: *fmf_source
     tmt_plan: test/fmf/plans/bootc-onboarding
     packages: [go-fdo-client-fedora]
     targets: # Temporarily disabling rawhide due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2427945
@@ -169,6 +175,7 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: e2e-centos
+    <<: *fmf_source
     tmt_plan: test/fmf/plans/e2e
     packages: [go-fdo-client-centos]
     targets: *copr_centos_targets


### PR DESCRIPTION
Update all three Packit test jobs (e2e-fedora, bootc-fedora, e2e-centos) to fetch FMF plans and test metadata from the shared go-fdo-ci repository instead of the local test/fmf/ directory.

Adds fmf_url, fmf_ref, and use_target_repo_for_fmf_url to ensure centralized test definitions and prevent fork PRs from bypassing tests.

Requires: https://github.com/fido-device-onboard/go-fdo-ci/pull/7

Co-Authored-By: Claude Sonnet 4.5