### PR TITLE
ci: add consolidated test jobs using go-fdo-ci scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 name: Continuous Integration
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,6 +11,7 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   test-makefile:
     name: build and test makefile
@@ -94,3 +96,82 @@ jobs:
         run: |
           source .github/scripts/container-utils.sh
           get_server_logs
+
+  test-native:
+    name: "Native: ${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test: test-onboarding
+            name: Test FIDO device onboarding
+          - test: test-onboarding-config
+            name: Test FIDO device onboarding using a configuration file
+          - test: test-onboarding-v2
+            name: Test FIDO device onboarding (V2 API)
+          - test: test-ov-verification
+            name: Test Ownership Voucher verification
+          - test: test-resale
+            name: Test FIDO resale protocol
+          - test: test-fsim-wget
+            name: Test FSIM fdo.wget
+          - test: test-fsim-upload
+            name: Test FSIM fdo.upload
+          - test: test-fsim-download
+            name: Test FSIM fdo.download
+          - test: test-fsim-command
+            name: Test FSIM fdo.command
+          - test: test-fsim-config
+            name: Test a sequence of FSIM operations using a configuration file
+          - test: test-device-ca-api
+            name: Test Device CA API
+          - test: test-device-ca-rendezvous-trust
+            name: Test Device CA rendezvous trust verification
+          - test: test-rv-bypass
+            name: Test RV bypass
+          - test: test-rv-bypass-v2
+            name: Test RV bypass (V2 API)
+          - test: test-rvinfo-apis-v2
+            name: Test RVInfo API Lifecycle (V2 API)
+    env:
+      CLIENT_LOCAL_PATH: ${{ github.workspace }}
+      SERVER_LOCAL_PATH: ${{ github.workspace }}/server
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Check out go-fdo-server
+        uses: actions/checkout@v4
+        with:
+          repository: fido-device-onboard/go-fdo-server
+          ref: ${{ inputs.go-fdo-server-branch || 'main' }}
+          path: server
+
+      - name: Check out go-fdo-ci
+        uses: actions/checkout@v4
+        with:
+          repository: fido-device-onboard/go-fdo-ci
+          path: ci
+
+      - name: ${{ matrix.name }}
+        run: |
+          source ci/test/ci/${{ matrix.test }}.sh
+          run_test
+
+      - name: Get Manufacturer, Rendezvous and Owner server logs
+        if: always()
+        run: |
+          source ci/test/ci/${{ matrix.test }}.sh
+          get_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source ci/test/ci/${{ matrix.test }}.sh
+          cleanup

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,84 @@
+name: Container Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      go-fdo-server-branch:
+        description: Go FDO server branch
+        default: main
+        required: true
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-container:
+    name: "Container: ${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test: test-onboarding
+            name: Test FIDO device onboarding
+          - test: test-onboarding-config
+            name: Test FIDO device onboarding using a configuration file
+          - test: test-onboarding-postgres
+            name: Test FIDO device onboarding (PostgreSQL)
+          - test: test-ov-verification
+            name: Test Ownership Voucher verification
+          - test: test-resale
+            name: Test FIDO resale protocol
+          - test: test-fsim-download
+            name: Test FSIM fdo.download
+          - test: test-fsim-upload
+            name: Test FSIM fdo.upload
+          - test: test-fsim-wget
+            name: Test FSIM fdo.wget
+          - test: test-device-ca-api
+            name: Test Device CA API
+          - test: test-device-ca-rendezvous-trust
+            name: Test Device CA rendezvous trust verification
+    env:
+      CLIENT_LOCAL_PATH: ${{ github.workspace }}
+      SERVER_LOCAL_PATH: ${{ github.workspace }}/server
+      COMPOSE_DIR: server/deployments/compose
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Check out go-fdo-server
+        uses: actions/checkout@v4
+        with:
+          repository: fido-device-onboard/go-fdo-server
+          ref: ${{ inputs.go-fdo-server-branch || 'main' }}
+          path: server
+
+      - name: Check out go-fdo-ci
+        uses: actions/checkout@v4
+        with:
+          repository: fido-device-onboard/go-fdo-ci
+          path: ci
+
+      - name: ${{ matrix.name }}
+        run: |
+          source ci/test/container/${{ matrix.test }}.sh
+          run_test
+
+      - name: Get Manufacturer, Rendezvous and Owner server logs
+        if: always()
+        run: |
+          source ci/test/container/${{ matrix.test }}.sh
+          get_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source ci/test/container/${{ matrix.test }}.sh
+          cleanup


### PR DESCRIPTION
### What
Add consolidated test jobs that use shared test scripts from `go-fdo-ci` repository. A `test-native` matrix job is added to
`ci.yaml`, running in parallel with existing legacy test jobs. A new `containers.yml` workflow is created with a `test-container` matrix job.

### Why
This PR is related to the discussion [#203](https://github.com/fido-device-onboard/go-fdo-server/discussions/203). Consolidating test scripts into `go-fdo-ci` repository enables consistent testing across Go FDO server and client repositories.

Assisted-by: Claude (claude-opus-4-6)